### PR TITLE
[STUDIO-004a] Add analysis canvas base interactions

### DIFF
--- a/docs/adr/011-canvas-framework-selection.md
+++ b/docs/adr/011-canvas-framework-selection.md
@@ -1,0 +1,136 @@
+# ADR-011: Analysis Canvas Framework Selection
+
+**Status:** Proposed
+**Date:** 2026-03-15
+**Deciders:** Mark Forster
+**PRD Reference:** [06_ARCHITECTURE.md - Analysis module](../prd/06_ARCHITECTURE.md)
+
+---
+
+## Context
+
+Issue `#192` requires the first non-placeholder canvas implementation for the Studio
+surface. The slice is intentionally narrow:
+
+- choose the base canvas implementation
+- deliver pan and zoom
+- support node drag
+- support typed edge creation
+- stay responsive at a 200-node interaction baseline
+
+The repo already points toward graph-centric canvas work:
+
+- `docs/RESEARCH_SYNTHESIS.md` recommends React Flow for DAG and provenance views
+- `docs/prd/06_ARCHITECTURE.md` explicitly calls for an ADR on the canvas framework
+- `STUDIO-004b` is the follow-on slice for persistence, so this decision should not
+  pull autosave or backend work into the current issue
+
+---
+
+## Decision
+
+Use **React Flow** (`@xyflow/react`) as the analysis canvas foundation for the Studio
+MVP and defer any broader whiteboard capability decision until collaboration,
+freeform drawing, or export requirements become concrete.
+
+---
+
+## Options Considered
+
+### Option 1: React Flow
+
+**Description:** Graph-focused React canvas library with built-in viewport, drag, and
+connection primitives.
+
+**Pros:**
+- MIT licensed
+- Direct support for pan, zoom, drag, handles, and edge creation
+- Strong fit for provenance, workflow, and decision graph use cases
+- Documented performance guidance for larger node sets
+
+**Cons:**
+- Graph-first, not a full whiteboard SDK
+- Styling and node chrome still need app-specific work
+
+### Option 2: Custom canvas engine
+
+**Description:** Build pan, zoom, drag, and link behavior directly in the app.
+
+**Pros:**
+- Full control over interaction and rendering model
+- No dependency on third-party abstractions
+
+**Cons:**
+- Recreates non-trivial viewport and hit-testing work
+- Higher regression risk before persistence is even in place
+- Slows delivery of the Studio roadmap for little immediate product gain
+
+### Option 3: tldraw or Excalidraw-first
+
+**Description:** Choose a whiteboard SDK before graph and provenance needs are fully
+specified.
+
+**Pros:**
+- Better long-term fit if the canvas becomes freeform and collaborative
+- Strong drawing ergonomics
+
+**Cons:**
+- Mismatch for the current graph-linking acceptance criteria
+- Adds whiteboard capability surface area before there is a board persistence contract
+
+---
+
+## Decision Rationale
+
+React Flow best matches the current problem shape. The issue is about stable board
+interactions for linked analysis objects, not about freehand drawing or multiplayer
+whiteboarding. React Flow gives the project a proven viewport, node drag, and edge
+creation baseline now, while keeping the board state aligned with the later
+`board/node/edge` persistence slice.
+
+---
+
+## Consequences
+
+### Positive
+
+- The placeholder analysis route now has a concrete interaction model
+- Later persistence work can serialize graph state directly
+- The framework choice stays aligned with provenance and workflow use cases
+
+### Negative
+
+- If the Studio evolves into a broad whiteboard product, a second ADR may still be needed
+- Some whiteboard behaviors will need custom work on top of the graph primitives
+
+### Risks
+
+- Risk: node chrome or layout choices could become too React Flow-specific
+  Mitigation: keep board data typed in app-level helpers rather than coupling logic to
+  view components
+- Risk: performance could regress once richer node content lands
+  Mitigation: keep a 200-node benchmark board in the UI and preserve React Flow's
+  recommended performance practices
+
+---
+
+## Implementation Notes
+
+- The initial UI ships with a curated working board and a 200-node benchmark board
+- Edge relations are typed now (`supports`, `derived-from`, `contradicts`) so
+  persistence can reuse the same contract
+- Persistence, autosave, and server CRUD remain explicitly deferred to `STUDIO-004b`
+
+---
+
+## Related ADRs
+
+- [ADR-005: Agent Runtime Framework](./005-agent-runtime-framework.md)
+
+---
+
+## References
+
+- [React Flow npm package metadata](https://www.npmjs.com/package/@xyflow/react)
+- [React Flow performance guide](https://reactflow.dev/learn/advanced-use/performance)
+- [Research synthesis notes](../RESEARCH_SYNTHESIS.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ An Architecture Decision Record (ADR) captures an important architectural decisi
 | [008](./008-mcp-tool-architecture.md) | MCP Tool Architecture | Proposed | 06_ARCHITECTURE.md, 03_PLATFORM.md |
 | [009](./009-human-in-the-loop-governance.md) | Human-in-the-Loop and Governance Patterns | Proposed | 06_ARCHITECTURE.md, 03_PLATFORM.md |
 | [010](./010-bootstrap-infrastructure.md) | Bootstrap Infrastructure — PostgreSQL + pgvector + Neo4j | Proposed | 03_PLATFORM.md |
+| [011](./011-canvas-framework-selection.md) | Analysis Canvas Framework Selection | Proposed | 06_ARCHITECTURE.md |
 
 ## Pending ADRs (from PRD Notes)
 
@@ -61,7 +62,7 @@ The following ADRs have been flagged in the PRD documents and need to be written
 |-------|------------|---------------|--------|
 | Research UI | 06_ARCHITECTURE.md | Panel layout, source ingestion, Deep vs Fast research | Pending |
 | Workbench UI | 06_ARCHITECTURE.md | IDE framework, terminal integration, file system | Pending |
-| Analysis Canvas | 06_ARCHITECTURE.md | Canvas framework, data model, collaboration, export | Pending |
+| Analysis Canvas | 06_ARCHITECTURE.md | Canvas framework, data model, collaboration, export | **→ [ADR-011](./011-canvas-framework-selection.md)** |
 | Cross-Session Analysis | 06_ARCHITECTURE.md | Permissions, pattern detection, coaching reports, privacy | Pending |
 | Generative UI Architecture | 06_ARCHITECTURE.md | Component library, AG-UI protocol, state sync, guardrails | Pending |
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,6 +11,7 @@
         "@ai-sdk/react": "^3.0.59",
         "@assistant-ui/react": "^0.12.3",
         "@assistant-ui/react-ai-sdk": "^1.3.3",
+        "@assistant-ui/react-markdown": "^0.12.5",
         "@assistant-ui/react-ui": "^0.2.1",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -31,6 +32,7 @@
         "@radix-ui/react-tooltip": "^1.1.2",
         "@tanstack/react-query": "^5.51.0",
         "@tanstack/react-query-devtools": "^5.51.0",
+        "@xyflow/react": "^12.10.1",
         "ai": "^6.0.57",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -44,10 +46,11 @@
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.4.0",
         "tailwindcss-animate": "^1.0.7",
-        "zustand": "^4.5.4"
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -189,30 +192,78 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@assistant-ui/react": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.12.3.tgz",
-      "integrity": "sha512-igqniJ+H7viLGjFD1yXBoBkkjbopggUVF7upjdaZvHCX+MdnWSgyuXNxZpvmVceo2pvyJ7iiCdSieHymWy1Rkw==",
+    "node_modules/@assistant-ui/core": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.5.tgz",
+      "integrity": "sha512-kLqFbRULZvE+hIwxGz705BW3QYhfwiVaVWoolfTGYkg+4xwah1PGuH0zqjXP5AMADtz+L69Lp+LX0xU9MQZ0DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@assistant-ui/store": "^0.1.2",
-        "@assistant-ui/tap": "^0.4.2",
+        "assistant-stream": "^0.3.5",
+        "nanoid": "^5.1.6"
+      },
+      "peerDependencies": {
+        "@assistant-ui/store": "^0.2.2",
+        "@assistant-ui/tap": "^0.5.2",
+        "@types/react": "*",
+        "assistant-cloud": "^0.1.21",
+        "react": "^18 || ^19",
+        "zustand": "^5.0.11"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "assistant-cloud": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "zustand": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/core/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@assistant-ui/react": {
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.12.17.tgz",
+      "integrity": "sha512-t4Z8LatD3LQrtURLaYPG47r4iG7UQgkdoi5YEv+EhzvYiG8I7kAyV4SbnFH6sXPrnleV4IpBHAd8Wc7ynkQtsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@assistant-ui/core": "^0.1.5",
+        "@assistant-ui/store": "^0.2.2",
+        "@assistant-ui/tap": "^0.5.2",
         "@radix-ui/primitive": "^1.1.3",
         "@radix-ui/react-compose-refs": "^1.1.2",
         "@radix-ui/react-context": "^1.1.3",
-        "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-primitive": "^2.1.4",
-        "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-use-callback-ref": "^1.1.1",
         "@radix-ui/react-use-escape-keydown": "^1.1.1",
-        "assistant-cloud": "^0.1.15",
-        "assistant-stream": "^0.3.0",
+        "assistant-cloud": "^0.1.21",
+        "assistant-stream": "^0.3.4",
         "nanoid": "^5.1.6",
+        "radix-ui": "^1.4.3",
         "react-textarea-autosize": "^8.5.9",
         "zod": "^4.3.6",
-        "zustand": "^5.0.10"
+        "zustand": "^5.0.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -255,9 +306,9 @@
       }
     },
     "node_modules/@assistant-ui/react-markdown": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react-markdown/-/react-markdown-0.12.1.tgz",
-      "integrity": "sha512-pwEa/Lj0NEaFhkkj5stTitOSQDE599p9P0SNv2I3GbN+7ETFC4esoELJbEXtblSMY9kyduzoB1+yfIdowEgR8w==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react-markdown/-/react-markdown-0.12.5.tgz",
+      "integrity": "sha512-oW1AzojSuNL4LXRkgRnXQaiAmUi1Ada7CfADwT/HCbGIYO5VJhm3u/ULsTiK6Uml7tRG4uVjgh61g+592QOD6w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "^2.1.4",
@@ -266,7 +317,7 @@
         "react-markdown": "^10.1.0"
       },
       "peerDependencies": {
-        "@assistant-ui/react": "^0.12.3",
+        "@assistant-ui/react": "^0.12.12",
         "@types/react": "*",
         "react": "^18 || ^19"
       },
@@ -343,35 +394,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@assistant-ui/react-ui/node_modules/zustand": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
-      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@assistant-ui/react/node_modules/@radix-ui/react-context": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
@@ -428,45 +450,16 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/@assistant-ui/react/node_modules/zustand": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
-      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@assistant-ui/store": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.1.2.tgz",
-      "integrity": "sha512-LOGjpK7Q07y14stu18pSk/0E5eZrYlxUNGKPkhZAZKvTPnw5eiy2yghbPGlxEGLMT7ZigJkkXoqcabjyw53VJA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.2.tgz",
+      "integrity": "sha512-JzQseWFp3UmbByBSWQmiGi/bz5jbfru04hIgb2DJBpnnTyns8Zl+8wDPnwiYGF/6SA+IzTg5M0V1wf77rwU0dA==",
       "license": "MIT",
       "dependencies": {
-        "@assistant-ui/tap": "^0.4.2",
         "use-effect-event": "^2.0.3"
       },
       "peerDependencies": {
+        "@assistant-ui/tap": "^0.5.2",
         "@types/react": "*",
         "react": "^18 || ^19"
       },
@@ -477,9 +470,9 @@
       }
     },
     "node_modules/@assistant-ui/tap": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.4.2.tgz",
-      "integrity": "sha512-iryNDkdsDkj7oYYt7L1dlJaeRuSjHzN7PE4Td1BiiVx1kfcBS6iXOaP/4G9NtVkxMGocdNJLjVv83Mwq7IVg/g==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.5.2.tgz",
+      "integrity": "sha512-w6gXhr+mF6cPG6ZCnkqV4kkOHzR+Fb+52S4T34PnrH0cs8l2Gqlwo/kB9BcB9fGmjwL7izdwubQ7t2VBhWpz/Q==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -525,7 +518,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -901,7 +893,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -925,7 +916,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1865,6 +1855,29 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-accordion": {
       "version": "1.2.12",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
@@ -1965,6 +1978,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
@@ -2014,6 +2050,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2327,6 +2393,88 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-icons": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
@@ -2454,6 +2602,138 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2634,6 +2914,62 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -2803,6 +3139,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -2817,6 +3186,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2869,6 +3267,112 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-layout-effect": "1.1.1",
         "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3544,7 +4048,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -3579,7 +4082,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3715,6 +4217,55 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3769,7 +4320,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3785,7 +4335,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3797,7 +4346,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3855,7 +4403,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4191,13 +4738,72 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz",
+      "integrity": "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.75",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz",
+      "integrity": "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4361,19 +4967,18 @@
       }
     },
     "node_modules/assistant-cloud": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.15.tgz",
-      "integrity": "sha512-LK+HrE6p1/jefzH3IosGUfpZvsM8wLPCsd955TLPEfJ9rMknl9KeE2QxRMHl3Ob17m33NqmJi/t/oWWKdgP6Nw==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.21.tgz",
+      "integrity": "sha512-KZ9ZsF1i1zMhozvD4m8TsmTdtufqULMaqgOoSLRyVtnhwvxkDufL87tSjv7epddZ4kbebe31biWSg7KIlgzvQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "assistant-stream": "^0.3.0"
+        "assistant-stream": "^0.3.4"
       }
     },
     "node_modules/assistant-stream": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.0.tgz",
-      "integrity": "sha512-gp5wXZiH7fiPdCByusRZ6ZQrmifAjiuDTenR0HSeviiRLXmirePxePvTgHPT1ZahohCLroge7fjtC9vAc+Hqsg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.5.tgz",
+      "integrity": "sha512-OGxVClfpEOoSsJDraPoe+GYTwh9TJX1wxK3hT5Qs7gIOyD/MZbqwyWwabRO2KTnNU4w7usvmC/vneUzxSk4bBg==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -4524,7 +5129,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4745,6 +5349,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -4943,6 +5553,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -5279,7 +5994,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6379,7 +7093,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6409,7 +7122,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -8066,7 +8778,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8282,12 +8993,179 @@
       ],
       "license": "MIT"
     },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8300,7 +9178,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9103,7 +9980,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -9273,7 +10149,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9446,7 +10321,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9746,7 +10620,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -9830,7 +10703,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -10152,26 +11024,23 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
+        "@types/react": ">=18.0.0",
         "immer": ">=9.0.6",
-        "react": ">=16.8"
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -10181,6 +11050,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@ai-sdk/react": "^3.0.59",
     "@assistant-ui/react": "^0.12.3",
     "@assistant-ui/react-ai-sdk": "^1.3.3",
+    "@assistant-ui/react-markdown": "^0.12.5",
     "@assistant-ui/react-ui": "^0.2.1",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -38,6 +39,7 @@
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.51.0",
     "@tanstack/react-query-devtools": "^5.51.0",
+    "@xyflow/react": "^12.10.1",
     "ai": "^6.0.57",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -51,10 +53,11 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "zustand": "^4.5.4"
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",

--- a/ui/src/components/analysis/AnalysisCanvas.tsx
+++ b/ui/src/components/analysis/AnalysisCanvas.tsx
@@ -1,0 +1,348 @@
+import { useRef, useState } from 'react'
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  Panel,
+  ReactFlow,
+  ReactFlowProvider,
+  SelectionMode,
+  useEdgesState,
+  useNodesState,
+  useReactFlow,
+  useViewport,
+} from '@xyflow/react'
+
+import '@xyflow/react/dist/style.css'
+
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import {
+  getNodeKindMeta,
+  AnalysisCanvasNode as AnalysisCanvasNodeComponent,
+} from '@/components/analysis/AnalysisCanvasNode'
+import {
+  EDGE_RELATION_LABELS,
+  addBoardNode,
+  connectBoardNodes,
+  type AnalysisBoard,
+  type AnalysisCanvasEdge,
+  type AnalysisCanvasNode as AnalysisCanvasNodeType,
+  type AnalysisEdgeRelation,
+} from '@/components/analysis/analysis-canvas-state'
+import {
+  createBenchmarkBoard,
+  createScenarioBoard,
+} from '@/components/analysis/analysis-canvas-fixtures'
+
+const nodeTypes = {
+  analysisNode: AnalysisCanvasNodeComponent,
+}
+
+type BoardMode = 'scenario' | 'benchmark'
+
+const RELATION_OPTIONS = Object.keys(EDGE_RELATION_LABELS) as AnalysisEdgeRelation[]
+
+export function AnalysisCanvas() {
+  const [boardMode, setBoardMode] = useState<BoardMode>('scenario')
+  const board = boardMode === 'scenario' ? createScenarioBoard() : createBenchmarkBoard(200)
+
+  return (
+    <ReactFlowProvider key={boardMode}>
+      <AnalysisCanvasWorkspace
+        board={board}
+        boardMode={boardMode}
+        onBoardModeChange={setBoardMode}
+      />
+    </ReactFlowProvider>
+  )
+}
+
+function AnalysisCanvasWorkspace({
+  board,
+  boardMode,
+  onBoardModeChange,
+}: {
+  board: AnalysisBoard
+  boardMode: BoardMode
+  onBoardModeChange: (mode: BoardMode) => void
+}) {
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const [nodes, setNodes, onNodesChange] = useNodesState<AnalysisCanvasNodeType>(board.nodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState<AnalysisCanvasEdge>(board.edges)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(board.nodes[0]?.id ?? null)
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
+  const [relation, setRelation] = useState<AnalysisEdgeRelation>('supports')
+  const reactFlow = useReactFlow<AnalysisCanvasNodeType, AnalysisCanvasEdge>()
+
+  function handleAddNode() {
+    if (!wrapperRef.current) {
+      return
+    }
+
+    const bounds = wrapperRef.current.getBoundingClientRect()
+    const position = reactFlow.screenToFlowPosition({
+      x: bounds.left + bounds.width / 2,
+      y: bounds.top + bounds.height / 2,
+    })
+
+    setNodes((currentNodes) => addBoardNode(currentNodes, 'note', position))
+  }
+
+  function handleResetBoard() {
+    setNodes(board.nodes)
+    setEdges(board.edges)
+    setSelectedNodeId(board.nodes[0]?.id ?? null)
+    setSelectedEdgeId(null)
+    queueMicrotask(() => {
+      reactFlow.fitView({ padding: 0.16 })
+    })
+  }
+
+  function handleFitView() {
+    reactFlow.fitView({ padding: 0.16 })
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-6 xl:flex-row">
+      <section className="flex min-h-[640px] min-w-0 flex-1 flex-col overflow-hidden rounded-3xl border bg-card shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-gradient-to-r from-background via-background to-muted/60 px-4 py-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-semibold">{board.name}</h2>
+              <span
+                data-testid="analysis-node-count"
+                className="rounded-full border bg-background px-2 py-0.5 text-[11px] text-muted-foreground"
+              >
+                {nodes.length} nodes
+              </span>
+              <span
+                data-testid="analysis-edge-count"
+                className="rounded-full border bg-background px-2 py-0.5 text-[11px] text-muted-foreground"
+              >
+                {edges.length} edges
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">{board.description}</p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant={boardMode === 'scenario' ? 'default' : 'outline'}
+              onClick={() => onBoardModeChange('scenario')}
+            >
+              Working board
+            </Button>
+            <Button
+              size="sm"
+              variant={boardMode === 'benchmark' ? 'default' : 'outline'}
+              onClick={() => onBoardModeChange('benchmark')}
+            >
+              Load 200-node benchmark
+            </Button>
+            <Button size="sm" variant="outline" onClick={handleAddNode}>
+              Add note
+            </Button>
+            <Button size="sm" variant="outline" onClick={handleFitView}>
+              Fit graph
+            </Button>
+            <Button size="sm" variant="ghost" onClick={handleResetBoard}>
+              Reset layout
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 border-b px-4 py-3">
+          <span className="text-xs font-medium text-muted-foreground">
+            New links default to
+          </span>
+          {RELATION_OPTIONS.map((option) => (
+            <Button
+              key={option}
+              size="sm"
+              variant={relation === option ? 'secondary' : 'ghost'}
+              className="h-8"
+              onClick={() => setRelation(option)}
+            >
+              {EDGE_RELATION_LABELS[option]}
+            </Button>
+          ))}
+        </div>
+
+        <div
+          ref={wrapperRef}
+          className="min-h-0 flex-1 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.10),transparent_32%),linear-gradient(180deg,rgba(248,250,252,0.96),rgba(241,245,249,0.78))]"
+        >
+          <ReactFlow
+            fitView
+            fitViewOptions={{ padding: 0.16 }}
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            selectionMode={SelectionMode.Partial}
+            snapToGrid
+            snapGrid={[16, 16]}
+            minZoom={0.25}
+            maxZoom={1.6}
+            attributionPosition="bottom-left"
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={(connection) =>
+              setEdges((currentEdges) => connectBoardNodes(currentEdges, connection, relation))
+            }
+            onSelectionChange={({ nodes: selectedNodes, edges: selectedEdges }) => {
+              setSelectedNodeId(selectedNodes[0]?.id ?? null)
+              setSelectedEdgeId(selectedEdges[0]?.id ?? null)
+            }}
+          >
+            <Background variant={BackgroundVariant.Dots} gap={28} size={1.15} />
+            <MiniMap
+              pannable
+              zoomable
+              className="!border !bg-background/90"
+              nodeColor={(node) =>
+                getNodeKindMeta(
+                  (node.data as AnalysisCanvasNodeType['data'] | undefined)?.kind ?? 'note'
+                ).minimapColor
+              }
+            />
+            <Controls />
+            <Panel
+              position="bottom-right"
+              className="rounded-2xl border bg-background/90 px-3 py-2 text-[11px] text-muted-foreground shadow-sm backdrop-blur"
+            >
+              Drag nodes to move them. Drag between handles to create a link.
+            </Panel>
+          </ReactFlow>
+        </div>
+      </section>
+
+      <AnalysisCanvasSidebar
+        boardMode={boardMode}
+        relation={relation}
+        nodes={nodes}
+        edges={edges}
+        selectedNodeId={selectedNodeId}
+        selectedEdgeId={selectedEdgeId}
+      />
+    </div>
+  )
+}
+
+function AnalysisCanvasSidebar({
+  boardMode,
+  relation,
+  nodes,
+  edges,
+  selectedNodeId,
+  selectedEdgeId,
+}: {
+  boardMode: BoardMode
+  relation: AnalysisEdgeRelation
+  nodes: AnalysisCanvasNodeType[]
+  edges: AnalysisCanvasEdge[]
+  selectedNodeId: string | null
+  selectedEdgeId: string | null
+}) {
+  const viewport = useViewport()
+  const selectedNode = nodes.find((node) => node.id === selectedNodeId) ?? null
+  const selectedEdge = edges.find((edge) => edge.id === selectedEdgeId) ?? null
+
+  return (
+    <aside className="flex w-full shrink-0 flex-col rounded-3xl border bg-card shadow-sm xl:w-[320px]">
+      <div className="px-5 py-4">
+        <h2 className="text-sm font-semibold">Canvas telemetry</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          React Flow is carrying viewport, drag, and graph-link interactions so later
+          persistence can stay focused on board data contracts.
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="grid grid-cols-3 gap-3 px-5 py-4">
+        <MetricCard label="Mode" value={boardMode === 'scenario' ? 'Curated' : 'Benchmark'} />
+        <MetricCard label="Zoom" value={`${Math.round(viewport.zoom * 100)}%`} />
+        <MetricCard label="Link type" value={EDGE_RELATION_LABELS[relation]} />
+      </div>
+
+      <Separator />
+
+      <div className="space-y-4 px-5 py-4 text-sm">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Viewport
+          </div>
+          <div className="mt-2 grid grid-cols-2 gap-3">
+            <MetricCard label="X" value={Math.round(viewport.x).toString()} />
+            <MetricCard label="Y" value={Math.round(viewport.y).toString()} />
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Selection
+          </div>
+          {selectedNode ? (
+            <div className="mt-2 rounded-2xl border bg-background p-4">
+              <div className="flex items-center justify-between gap-2">
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${
+                    getNodeKindMeta(selectedNode.data.kind).badge
+                  }`}
+                >
+                  {getNodeKindMeta(selectedNode.data.kind).label}
+                </span>
+                <span className="text-[11px] text-muted-foreground">
+                  {selectedNode.position.x}, {selectedNode.position.y}
+                </span>
+              </div>
+              <div className="mt-3 text-sm font-semibold">{selectedNode.data.title}</div>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {selectedNode.data.summary}
+              </p>
+              <div className="mt-3 text-[11px] text-muted-foreground">
+                Owner: {selectedNode.data.owner}
+              </div>
+            </div>
+          ) : selectedEdge ? (
+            <div className="mt-2 rounded-2xl border bg-background p-4 text-xs text-muted-foreground">
+              <div className="font-medium text-foreground">
+                {EDGE_RELATION_LABELS[selectedEdge.data?.relation ?? 'supports']}
+              </div>
+              <div className="mt-2">
+                {selectedEdge.source} to {selectedEdge.target}
+              </div>
+            </div>
+          ) : (
+            <div className="mt-2 rounded-2xl border bg-background p-4 text-xs text-muted-foreground">
+              Select a node or edge to inspect it here.
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Interaction contract
+          </div>
+          <div className="mt-2 space-y-2 rounded-2xl border bg-background p-4 text-xs text-muted-foreground">
+            <p>Pan and zoom stay on the canvas, not the page shell.</p>
+            <p>Node drag updates position state for future persistence.</p>
+            <p>Edge creation is typed now so the next slice can persist relations directly.</p>
+          </div>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border bg-background px-3 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="mt-1 text-sm font-semibold">{value}</div>
+    </div>
+  )
+}

--- a/ui/src/components/analysis/AnalysisCanvas.tsx
+++ b/ui/src/components/analysis/AnalysisCanvas.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import {
   Background,
   BackgroundVariant,
@@ -46,7 +46,9 @@ const RELATION_OPTIONS = Object.keys(EDGE_RELATION_LABELS) as AnalysisEdgeRelati
 
 export function AnalysisCanvas() {
   const [boardMode, setBoardMode] = useState<BoardMode>('scenario')
-  const board = boardMode === 'scenario' ? createScenarioBoard() : createBenchmarkBoard(200)
+  const scenarioBoard = useMemo(() => createScenarioBoard(), [])
+  const benchmarkBoard = useMemo(() => createBenchmarkBoard(200), [])
+  const board = boardMode === 'scenario' ? scenarioBoard : benchmarkBoard
 
   return (
     <ReactFlowProvider key={boardMode}>

--- a/ui/src/components/analysis/AnalysisCanvasNode.tsx
+++ b/ui/src/components/analysis/AnalysisCanvasNode.tsx
@@ -1,0 +1,108 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+
+import { cn } from '@/lib/utils'
+import type {
+  AnalysisCanvasNode,
+  AnalysisNodeKind,
+} from '@/components/analysis/analysis-canvas-state'
+
+const NODE_KIND_META: Record<
+  AnalysisNodeKind,
+  {
+    label: string
+    accent: string
+    badge: string
+    minimapColor: string
+  }
+> = {
+  note: {
+    label: 'Note',
+    accent: 'bg-sky-500',
+    badge: 'border-sky-500/20 bg-sky-500/10 text-sky-700',
+    minimapColor: '#0ea5e9',
+  },
+  artifact: {
+    label: 'Artifact',
+    accent: 'bg-emerald-500',
+    badge: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700',
+    minimapColor: '#10b981',
+  },
+  reportSnippet: {
+    label: 'Snippet',
+    accent: 'bg-violet-500',
+    badge: 'border-violet-500/20 bg-violet-500/10 text-violet-700',
+    minimapColor: '#8b5cf6',
+  },
+  decision: {
+    label: 'Decision',
+    accent: 'bg-amber-500',
+    badge: 'border-amber-500/20 bg-amber-500/10 text-amber-700',
+    minimapColor: '#f59e0b',
+  },
+  chartPlaceholder: {
+    label: 'Chart',
+    accent: 'bg-rose-500',
+    badge: 'border-rose-500/20 bg-rose-500/10 text-rose-700',
+    minimapColor: '#f43f5e',
+  },
+}
+
+export function getNodeKindMeta(kind: AnalysisNodeKind) {
+  return NODE_KIND_META[kind]
+}
+
+export function AnalysisCanvasNode({
+  data,
+  selected,
+}: NodeProps<AnalysisCanvasNode>) {
+  const meta = getNodeKindMeta(data.kind)
+
+  return (
+    <div
+      className={cn(
+        'min-w-[220px] max-w-[240px] rounded-2xl border bg-background/95 shadow-[0_12px_30px_-18px_rgba(15,23,42,0.45)] backdrop-blur',
+        selected ? 'border-primary/60 ring-2 ring-primary/20' : 'border-border/70'
+      )}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!h-3 !w-3 !border-2 !border-background !bg-slate-700"
+      />
+
+      <div className="flex gap-3 p-4">
+        <div className={cn('w-1 rounded-full', meta.accent)} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <span
+              className={cn(
+                'rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]',
+                meta.badge
+              )}
+            >
+              {meta.label}
+            </span>
+            <span className="text-[10px] text-muted-foreground">{data.status}</span>
+          </div>
+
+          <div className="mt-3 text-sm font-semibold leading-snug text-foreground">
+            {data.title}
+          </div>
+
+          <p className="mt-2 text-xs leading-relaxed text-muted-foreground">{data.summary}</p>
+
+          <div className="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
+            <span>{data.owner}</span>
+            <span>{selected ? 'Selected' : 'Drag to move'}</span>
+          </div>
+        </div>
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!h-3 !w-3 !border-2 !border-background !bg-slate-700"
+      />
+    </div>
+  )
+}

--- a/ui/src/components/analysis/analysis-canvas-fixtures.ts
+++ b/ui/src/components/analysis/analysis-canvas-fixtures.ts
@@ -1,0 +1,180 @@
+import {
+  createBoardEdge,
+  createBoardNode,
+  type AnalysisBoard,
+  type AnalysisCanvasEdge,
+  type AnalysisCanvasNode,
+  type AnalysisEdgeRelation,
+  type AnalysisNodeKind,
+} from '@/components/analysis/analysis-canvas-state'
+
+const BENCHMARK_KINDS: AnalysisNodeKind[] = [
+  'artifact',
+  'note',
+  'reportSnippet',
+  'decision',
+  'chartPlaceholder',
+]
+
+const BENCHMARK_RELATIONS: AnalysisEdgeRelation[] = [
+  'supports',
+  'derived-from',
+  'supports',
+  'contradicts',
+]
+
+export function createScenarioBoard(): AnalysisBoard {
+  const leaseSchedule = createBoardNode({
+    id: 'artifact-lease-schedule',
+    kind: 'artifact',
+    position: { x: 80, y: 80 },
+    title: 'Lease schedule',
+    summary: 'Primary source bundle covering rent rolls, covenant thresholds, and expiry risk.',
+    owner: 'Research',
+    status: 'Source',
+  })
+
+  const covenantDelta = createBoardNode({
+    id: 'report-covenant-delta',
+    kind: 'reportSnippet',
+    position: { x: 420, y: 40 },
+    title: 'Coverage delta',
+    summary: 'Draft narrative describing cash coverage compression in the downside case.',
+    owner: 'Reporting',
+    status: 'Review',
+  })
+
+  const valuationPressure = createBoardNode({
+    id: 'note-valuation-pressure',
+    kind: 'note',
+    position: { x: 740, y: 110 },
+    title: 'Valuation pressure',
+    summary: 'Potential NAV pressure if expiring units re-let below current assumptions.',
+    owner: 'Analyst',
+    status: 'Working',
+  })
+
+  const decisionReview = createBoardNode({
+    id: 'decision-escalate-review',
+    kind: 'decision',
+    position: { x: 740, y: 360 },
+    title: 'Escalate committee review',
+    summary: 'Decision gate for whether the credit committee needs a formal watchlist review.',
+    owner: 'Investment committee',
+    status: 'Pending',
+  })
+
+  const sensitivityChart = createBoardNode({
+    id: 'chart-sensitivity',
+    kind: 'chartPlaceholder',
+    position: { x: 380, y: 340 },
+    title: 'Sensitivity chart',
+    summary: 'Reserved frame for debt yield and covenant headroom once chart output is wired.',
+    owner: 'Studio',
+    status: 'Scaffold',
+  })
+
+  const renewalRisk = createBoardNode({
+    id: 'note-renewal-risk',
+    kind: 'note',
+    position: { x: 80, y: 360 },
+    title: 'Renewal risk cluster',
+    summary: 'Group expiring tenants by rent reversion risk and capture linked evidence.',
+    owner: 'Analyst',
+    status: 'Draft',
+  })
+
+  const nodes = [
+    leaseSchedule,
+    covenantDelta,
+    valuationPressure,
+    decisionReview,
+    sensitivityChart,
+    renewalRisk,
+  ]
+
+  const edges = [
+    createBoardEdge(
+      { source: leaseSchedule.id, target: covenantDelta.id },
+      'derived-from'
+    ),
+    createBoardEdge(
+      { source: covenantDelta.id, target: valuationPressure.id },
+      'supports'
+    ),
+    createBoardEdge(
+      { source: valuationPressure.id, target: decisionReview.id },
+      'supports'
+    ),
+    createBoardEdge(
+      { source: renewalRisk.id, target: decisionReview.id },
+      'contradicts'
+    ),
+    createBoardEdge(
+      { source: sensitivityChart.id, target: decisionReview.id },
+      'supports'
+    ),
+  ].filter(Boolean) as AnalysisCanvasEdge[]
+
+  return {
+    name: 'Working board',
+    description:
+      'Curated starter board for linked evidence, analysis notes, and decision framing.',
+    nodes,
+    edges,
+  }
+}
+
+export function createBenchmarkBoard(nodeCount = 200): AnalysisBoard {
+  const columns = 10
+  const xGap = 230
+  const yGap = 150
+
+  const nodes: AnalysisCanvasNode[] = Array.from({ length: nodeCount }, (_, index) => {
+    const row = Math.floor(index / columns)
+    const column = index % columns
+    const kind = BENCHMARK_KINDS[index % BENCHMARK_KINDS.length]
+
+    return createBoardNode({
+      id: `benchmark-node-${index + 1}`,
+      kind,
+      position: { x: column * xGap, y: row * yGap },
+      title: `Benchmark node ${index + 1}`,
+      summary: 'Seeded canvas item for viewport pan, zoom, drag, and edge interaction checks.',
+      owner: row % 2 === 0 ? 'Studio' : 'Analyst',
+      status: row % 3 === 0 ? 'Active' : 'Tracked',
+    })
+  })
+
+  const edges: AnalysisCanvasEdge[] = []
+
+  for (let index = 1; index < nodes.length; index += 1) {
+    const sequential = createBoardEdge(
+      { source: nodes[index - 1].id, target: nodes[index].id },
+      BENCHMARK_RELATIONS[(index - 1) % BENCHMARK_RELATIONS.length]
+    )
+
+    if (sequential) {
+      edges.push(sequential)
+    }
+
+    if (index >= columns && index % 3 === 0) {
+      const columnAnchor = createBoardEdge(
+        { source: nodes[index - columns].id, target: nodes[index].id },
+        'supports'
+      )
+
+      if (columnAnchor) {
+        edges.push(columnAnchor)
+      }
+    }
+  }
+
+  return {
+    name: '200-node benchmark',
+    description:
+      'Stress board for confirming the viewport and drag baseline before persistence work.',
+    nodes,
+    edges,
+  }
+}

--- a/ui/src/components/analysis/analysis-canvas-state.ts
+++ b/ui/src/components/analysis/analysis-canvas-state.ts
@@ -1,0 +1,194 @@
+import {
+  MarkerType,
+  addEdge,
+  type Edge,
+  type Node,
+  type XYPosition,
+} from '@xyflow/react'
+
+export type AnalysisNodeKind =
+  | 'note'
+  | 'artifact'
+  | 'reportSnippet'
+  | 'decision'
+  | 'chartPlaceholder'
+
+export type AnalysisEdgeRelation = 'supports' | 'derived-from' | 'contradicts'
+
+export type AnalysisNodeData = {
+  kind: AnalysisNodeKind
+  title: string
+  summary: string
+  owner: string
+  status: string
+}
+
+export type AnalysisEdgeData = {
+  relation: AnalysisEdgeRelation
+}
+
+export type AnalysisCanvasNode = Node<AnalysisNodeData, 'analysisNode'>
+export type AnalysisCanvasEdge = Edge<AnalysisEdgeData, 'smoothstep'>
+export type BoardConnection = {
+  source: string | null
+  target: string | null
+  sourceHandle?: string | null
+  targetHandle?: string | null
+}
+
+export type AnalysisBoard = {
+  name: string
+  description: string
+  nodes: AnalysisCanvasNode[]
+  edges: AnalysisCanvasEdge[]
+}
+
+export const EDGE_RELATION_LABELS: Record<AnalysisEdgeRelation, string> = {
+  supports: 'Supports',
+  'derived-from': 'Derived from',
+  contradicts: 'Contradicts',
+}
+
+const NODE_COPY: Record<
+  AnalysisNodeKind,
+  { label: string; summary: string; owner: string; status: string }
+> = {
+  note: {
+    label: 'Working note',
+    summary: 'Quick synthesis point that can be moved and linked as evidence arrives.',
+    owner: 'Analyst',
+    status: 'Draft',
+  },
+  artifact: {
+    label: 'Artifact',
+    summary: 'Source artifact or output frame that anchors linked reasoning.',
+    owner: 'Ingest',
+    status: 'Tracked',
+  },
+  reportSnippet: {
+    label: 'Report snippet',
+    summary: 'A report fragment or claim block that needs provenance and review.',
+    owner: 'Reporting',
+    status: 'Review',
+  },
+  decision: {
+    label: 'Decision',
+    summary: 'Decision node capturing a choice, owner, and follow-up work.',
+    owner: 'Decision desk',
+    status: 'Pending',
+  },
+  chartPlaceholder: {
+    label: 'Chart placeholder',
+    summary: 'Reserved space for chart output once the data contract is wired in.',
+    owner: 'Studio',
+    status: 'Scaffold',
+  },
+}
+
+type CreateBoardNodeOptions = {
+  id?: string
+  kind: AnalysisNodeKind
+  position: XYPosition
+  title?: string
+  summary?: string
+  owner?: string
+  status?: string
+}
+
+export function createBoardNode(options: CreateBoardNodeOptions): AnalysisCanvasNode {
+  const copy = NODE_COPY[options.kind]
+
+  return {
+    id: options.id ?? crypto.randomUUID(),
+    type: 'analysisNode',
+    position: options.position,
+    data: {
+      kind: options.kind,
+      title: options.title ?? copy.label,
+      summary: options.summary ?? copy.summary,
+      owner: options.owner ?? copy.owner,
+      status: options.status ?? copy.status,
+    },
+  }
+}
+
+export function addBoardNode(
+  nodes: AnalysisCanvasNode[],
+  kind: AnalysisNodeKind,
+  position: XYPosition
+): AnalysisCanvasNode[] {
+  const nextIndex = nodes.filter((node) => node.data.kind === kind).length + 1
+
+  return [
+    ...nodes,
+    createBoardNode({
+      kind,
+      position,
+      title: `${NODE_COPY[kind].label} ${nextIndex}`,
+      status: 'New',
+    }),
+  ]
+}
+
+export function moveBoardNode(
+  nodes: AnalysisCanvasNode[],
+  nodeId: string,
+  position: XYPosition
+): AnalysisCanvasNode[] {
+  return nodes.map((node) => (node.id === nodeId ? { ...node, position } : node))
+}
+
+export function createBoardEdge(
+  connection: BoardConnection,
+  relation: AnalysisEdgeRelation = 'supports'
+): AnalysisCanvasEdge | null {
+  if (!connection.source || !connection.target) {
+    return null
+  }
+
+  const stroke =
+    relation === 'contradicts'
+      ? '#dc2626'
+      : relation === 'derived-from'
+        ? '#2563eb'
+        : '#0f766e'
+
+  return {
+    id: `${connection.source}-${connection.target}-${relation}-${crypto.randomUUID()}`,
+    source: connection.source,
+    target: connection.target,
+    sourceHandle: connection.sourceHandle,
+    targetHandle: connection.targetHandle,
+    type: 'smoothstep',
+    label: EDGE_RELATION_LABELS[relation],
+    animated: relation === 'derived-from',
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 18,
+      height: 18,
+      color: stroke,
+    },
+    style: {
+      stroke,
+      strokeWidth: relation === 'contradicts' ? 2.5 : 2,
+    },
+    labelStyle: {
+      fill: '#475569',
+      fontSize: 11,
+      fontWeight: 600,
+    },
+    data: {
+      relation,
+    },
+  }
+}
+
+export function connectBoardNodes(
+  edges: AnalysisCanvasEdge[],
+  connection: BoardConnection,
+  relation: AnalysisEdgeRelation = 'supports'
+): AnalysisCanvasEdge[] {
+  const edge = createBoardEdge(connection, relation)
+
+  return edge ? (addEdge(edge, edges) as AnalysisCanvasEdge[]) : edges
+}

--- a/ui/src/pages/AnalysisPage.tsx
+++ b/ui/src/pages/AnalysisPage.tsx
@@ -1,18 +1,48 @@
-import { ModulePlaceholder } from '@/pages/ModulePlaceholder'
+import { BarChart3 } from 'lucide-react'
+
+import { AnalysisCanvas } from '@/components/analysis/AnalysisCanvas'
 
 export function AnalysisPage() {
   return (
-    <ModulePlaceholder
-      title="Analysis Intelligence"
-      tagline="Repeatable analysis that turns sources into structured outputs: tables, entities, relationships, and evidence-linked claims."
-      status="next"
-      bullets={[
-        'DAG-style workflows that emit artifacts (tables/graphs/JSON) with provenance',
-        'Entity/relationship extraction aligned to industry ontologies',
-        'Comparisons and validations (IC memo vs model vs legal agreements)',
-        'Levels of care: “quick read” vs “investment-grade” workflows',
-      ]}
-    />
+    <div className="flex h-full flex-col">
+      <header className="border-b bg-background/95 px-6 py-5 backdrop-blur">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <BarChart3 className="h-5 w-5" />
+            </div>
+            <div className="space-y-2">
+              <div>
+                <h1 className="text-lg font-semibold tracking-tight">Analysis Canvas</h1>
+                <p className="max-w-2xl text-sm text-muted-foreground">
+                  Graph-first workspace for provenance, decisions, and linked analysis.
+                  This slice establishes base pan, zoom, drag, and edge creation before
+                  persistence lands.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2 text-[11px] font-medium">
+                <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1 text-emerald-700">
+                  React Flow selected
+                </span>
+                <span className="rounded-full border border-sky-500/20 bg-sky-500/10 px-2.5 py-1 text-sky-700">
+                  DAG and provenance ready
+                </span>
+                <span className="rounded-full border border-amber-500/20 bg-amber-500/10 px-2.5 py-1 text-amber-700">
+                  200-node benchmark seeded
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="max-w-sm rounded-2xl border bg-card/80 px-4 py-3 text-xs text-muted-foreground shadow-sm">
+            Start on the curated board, then switch to the benchmark board to validate the
+            interaction baseline against the issue target without dragging persistence into
+            this slice.
+          </div>
+        </div>
+      </header>
+
+      <AnalysisCanvas />
+    </div>
   )
 }
-

--- a/ui/src/pages/__tests__/AnalysisPage.test.tsx
+++ b/ui/src/pages/__tests__/AnalysisPage.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+import { AnalysisPage } from '@/pages/AnalysisPage'
+import {
+  connectBoardNodes,
+  moveBoardNode,
+} from '@/components/analysis/analysis-canvas-state'
+import {
+  createBenchmarkBoard,
+  createScenarioBoard,
+} from '@/components/analysis/analysis-canvas-fixtures'
+
+describe('AnalysisPage', () => {
+  it('renders the analysis canvas shell and benchmark entry point', () => {
+    render(
+      <MemoryRouter>
+        <AnalysisPage />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Analysis Canvas' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Load 200-node benchmark' })).toBeInTheDocument()
+    expect(screen.getByTestId('analysis-node-count')).toHaveTextContent('6 nodes')
+  })
+
+  it('adds a note node from the toolbar', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <AnalysisPage />
+      </MemoryRouter>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Add note' }))
+
+    expect(screen.getByTestId('analysis-node-count')).toHaveTextContent('7 nodes')
+  })
+})
+
+describe('analysis canvas state helpers', () => {
+  it('moves nodes by id', () => {
+    const board = createScenarioBoard()
+    const moved = moveBoardNode(board.nodes, board.nodes[0].id, { x: 512, y: 384 })
+
+    expect(moved[0].position).toEqual({ x: 512, y: 384 })
+    expect(board.nodes[0].position).toEqual({ x: 80, y: 80 })
+  })
+
+  it('creates typed edges through the connection helper', () => {
+    const board = createScenarioBoard()
+    const edges = connectBoardNodes(
+      board.edges,
+      { source: board.nodes[1].id, target: board.nodes[4].id },
+      'contradicts'
+    )
+    const createdEdge = edges.find(
+      (edge) =>
+        edge.source === board.nodes[1].id &&
+        edge.target === board.nodes[4].id &&
+        edge.data?.relation === 'contradicts'
+    )
+
+    expect(createdEdge?.data?.relation).toBe('contradicts')
+    expect(createdEdge?.label).toBe('Contradicts')
+  })
+
+  it('builds the benchmark board with 200 seeded nodes', () => {
+    const board = createBenchmarkBoard()
+
+    expect(board.nodes).toHaveLength(200)
+    expect(board.edges.length).toBeGreaterThan(199)
+  })
+})


### PR DESCRIPTION
## Summary
- replace the `/analysis` placeholder with a React Flow canvas tuned for graph-first studio work
- add base pan/zoom, node drag, typed edge creation, and a seeded 200-node benchmark board
- document the framework selection in ADR-011 and add focused AnalysisPage/state tests
- align the existing UI dependency graph so the frontend build and full Vitest suite pass

Closes #192.

## Validation
- `npm run test` in `ui/`
- `npm run build` in `ui/`
- `uv run ruff format src/ tests/`
- `uv run ruff check src/ tests/`
- `uv run pytest` *(fails in pre-existing e2e/integration flows: agent chat auth expectations and S3-backed artifact/manifest/pointer tests reporting 401s / missing credentials)*